### PR TITLE
Fix bug where pr's are closed instead of merged

### DIFF
--- a/internal/pullrequest.go
+++ b/internal/pullrequest.go
@@ -69,7 +69,11 @@ func (g *GithubIntegration) fromPullRequestEvent(logger sdk.Logger, client sdk.G
 		object.Locked = *pr.PullRequest.Locked
 		object.Merged = *pr.PullRequest.Merged
 		object.Number = *pr.PullRequest.Number
-		object.State = strings.ToUpper(*pr.PullRequest.State)
+		state := strings.ToUpper(*pr.PullRequest.State)
+		if object.Merged {
+			state = "MERGED"
+		}
+		object.State = state
 		object.Title = *pr.PullRequest.Title
 		object.CreatedAt = *pr.PullRequest.CreatedAt
 		if pr.PullRequest.UpdatedAt != nil {


### PR DESCRIPTION
when you merge a pr the event will call the state `closed`, instead of `merged`