### PR TITLE
GOLD-475 skip entities that are not issues

### DIFF
--- a/internal/project.go
+++ b/internal/project.go
@@ -19,10 +19,10 @@ type repoProjectCardContent struct {
 }
 
 type repoProjectCard struct {
-	ID      string                 `json:"id"`
-	State   string                 `json:"state"`
-	Note    string                 `json:"note"`
-	Content repoProjectCardContent `json:"content"`
+	ID      string                  `json:"id"`
+	State   string                  `json:"state"`
+	Note    string                  `json:"note"`
+	Content *repoProjectCardContent `json:"content"`
 }
 
 type repoProjectCardNodes struct {
@@ -113,9 +113,11 @@ func (p repoProject) ToModel(logger sdk.Logger, customerID string, integrationIn
 		col.Name = c.Name
 		col.IssueIds = make([]string, 0)
 		for _, o := range c.Cards.Nodes {
-			id := sdk.NewWorkIssueID(customerID, o.Content.ID, refType)
-			col.IssueIds = append(col.IssueIds, id)
-			kanban.IssueIds = append(kanban.IssueIds, id)
+			if o.Content != nil {
+				id := sdk.NewWorkIssueID(customerID, o.Content.ID, refType)
+				col.IssueIds = append(col.IssueIds, id)
+				kanban.IssueIds = append(kanban.IssueIds, id)
+			}
 		}
 		kanban.Columns = append(kanban.Columns, col)
 		var bcol sdk.AgileBoardColumns


### PR DESCRIPTION
There is an entity in GitHub called Card which was being counted as issue for Kanban boards. As the issue id was empty in each card the same id was being added to the column, resulting in the problem in the UI. This is an example of the output of the api.:

```
{
   "id": "MDExOlByb2plY3RDYX=",
   "__typename": "ProjectCard",
   "state": "NOTE_ONLY",
   "note": "car test",
   "content": null // output for a card in the column
},
{
   "id": "MDExOlByb2plY3RDYXJ=",
   "__typename": "ProjectCard",
   "state": "CONTENT_ONLY",
   "note": null,
   "content": { // output for an issue in the column
         "__typename": "Issue",
         "id": "MDU6SXNzdWU3MzA4OTE5Njc="
    }
},
```